### PR TITLE
Improve roles & add release checklist and role template

### DIFF
--- a/docs/checklists/release-readiness-checklist.md
+++ b/docs/checklists/release-readiness-checklist.md
@@ -1,0 +1,30 @@
+# Release Readiness Checklist
+
+Purpose: A concise checklist for Release Managers, Project Managers, QA Lead, and Developers to confirm readiness before a production deployment.
+
+Owner: Release Manager (primary), Project Manager (secondary)
+
+Pre-release checks
+- [ ] Release branch / tag created and CI pipeline is green
+- [ ] All PRs merged for the release and linked to issues
+- [ ] Acceptance criteria are met for items in release (per issue/PR)
+- [ ] Regression and smoke test plan executed and passed (QA Lead signoff)
+- [ ] Security scans completed and no critical findings
+- [ ] Migration/DB changes planned with rollback steps
+- [ ] Rollback and mitigation plan documented and tested (if applicable)
+- [ ] Release notes drafted and reviewed (Product Manager / Release Manager)
+- [ ] Stakeholders & Support notified of release window and expected impact
+- [ ] Monitoring and alerting configured for new/changed functionality
+- [ ] On-call / Support Engineer informed and ready
+
+Deployment
+- [ ] Backup or snapshot (if applicable)
+- [ ] Deployment steps executed (automated pipeline preferred)
+- [ ] Post-deploy smoke tests run and passed
+- [ ] Production monitoring checks OK
+- [ ] Announce release to stakeholders and relevant channels
+
+Post-release
+- [ ] Monitor for at least the agreed observation window
+- [ ] Capture any incidents and create follow-up action items
+- [ ] Update retrospective/action tracker for process improvements

--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -79,3 +79,127 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 - Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
 - Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.
 
+---
+
+## Proposed Additional Personas (New)
+
+The following personas clarify ownership across release, quality, design, support, and business analysis. Adding these roles reduces ambiguity, clarifies handoffs, and improves cross-team coordination.
+
+### Release Manager
+
+#### Role Summary
+Coordinates and owns release planning, readiness, and deployment execution across teams.
+
+#### Responsibilities
+- Maintain the release schedule and coordinate release windows
+- Verify pre-release conditions (CI, test coverage, release notes, rollback plan)
+- Coordinate cross-team release readiness checks and runbooks
+- Communicate release timing and scope to stakeholders and support
+- Drive post-release retrospectives for release processes
+
+#### Goals
+- Reduce release-related incidents and rollbacks
+- Make release cadence predictable and transparent
+
+#### Typical Communication & Interactions
+- Works closely with Project Manager, Product Manager, QA Lead, Developers, and Support Engineer
+- Sends release readiness summaries to stakeholders and on-call/support channels
+
+---
+
+### QA Lead
+
+#### Role Summary
+Leads the testing strategy and ensures work meets defined quality standards prior to release.
+
+#### Responsibilities
+- Define test strategy for features and releases (manual & automated)
+- Coordinate QA resources, test plans, and acceptance verification
+- Maintain test automation coverage priorities and failure triage
+- Escalate unresolved quality risks to PM/Release Manager
+
+#### Goals
+- Ensure acceptance criteria are validated before release
+- Reduce production defects and regressions
+
+#### Typical Communication & Interactions
+- Partners with Developers, Product Manager, and Release Manager to validate readiness
+- Provides test summary and known issues to Release Manager and Support
+
+---
+
+### UX Designer
+
+#### Role Summary
+Owns user experience design and validation to ensure delivered features meet usability and accessibility goals.
+
+#### Responsibilities
+- Create user flows, wireframes, and high-fidelity designs as needed
+- Run usability testing and incorporate feedback into acceptance criteria
+- Define UX acceptance criteria and accessibility checks
+- Advise on design trade-offs during planning
+
+#### Goals
+- Improve user satisfaction and reduce usability-related rework
+
+#### Typical Communication & Interactions
+- Collaborates with Product Manager on requirements and success criteria
+- Works with Developers and QA Lead to ensure designs are implemented and tested
+
+---
+
+### Support Engineer
+
+#### Role Summary
+First line for customer-facing incidents and support; converts operational feedback into actionable issues.
+
+#### Responsibilities
+- Triage production issues and provide timely incident updates
+- Document reproducible steps and collect logs/metrics for engineers
+- Coordinate with Release Manager and PM for rollouts and mitigations
+- Maintain the incident / postmortem artifacts and communicate customer impact
+
+#### Goals
+- Reduce time-to-detect and time-to-resolve production problems
+- Provide actionable feedback to engineering and product teams
+
+#### Typical Communication & Interactions
+- Communicates incidents to PM and Release Manager
+- Feeds prioritized issues into the backlog and risk register
+
+---
+
+### Business Analyst
+
+#### Role Summary
+Bridges business stakeholders and delivery teams by formalizing requirements and acceptance criteria.
+
+#### Responsibilities
+- Elicit and document business rules, constraints, and non-functional requirements
+- Produce clear user stories and acceptance criteria aligned to business outcomes
+- Validate delivered features against business needs and data
+
+#### Goals
+- Reduce rework due to ambiguous requirements
+- Ensure delivered functionality meets stakeholder expectations
+
+#### Typical Communication & Interactions
+- Works with Product Manager, PM, Developers, and Stakeholders to clarify scope
+- Participates in acceptance testing and sign-offs
+
+---
+
+## Role Interaction Guidelines & Suggested Artifacts
+
+- Add an immediate “Role Owner” field on backlog items (Owner = Developer, QA Lead, UX Designer, etc.) to make handoffs explicit.
+- Use a simple RACI mapping for major deliverables (e.g., release plan, build, test, deploy):
+  - Responsible: Release Manager / Developer
+  - Accountable: Project Manager / Product Manager
+  - Consulted: QA Lead / UX Designer / Business Analyst
+  - Informed: Stakeholders, Support
+- Suggested artifact additions per project:
+  - Role contact list in project README (names & responsibilities)
+  - Release readiness checklist (see docs/checklists/release-readiness-checklist.md)
+  - Role Responsibility template (docs/templates/role-responsibility-template.md)
+
+---

--- a/docs/templates/role-responsibility-template.md
+++ b/docs/templates/role-responsibility-template.md
@@ -1,0 +1,19 @@
+# Role Responsibility Template
+
+Use this template to document role responsibilities for a project or feature.
+
+- Role name:
+- Role owner (person or rotation):
+- Role summary:
+- Key responsibilities:
+  - [ ]
+- Deliverables / artifacts owned:
+  - [ ]
+- Primary interactions (who they hand off to / receive from):
+  - [ ]
+- Escalation path:
+  - [ ]
+- Typical communication cadence (meetings, reports, channels):
+  - [ ]
+- Success metrics for role (how we know the role is effective):
+  - [ ]


### PR DESCRIPTION
This PR expands the roles/personas documentation (adds Release Manager, QA Lead, UX Designer, Support Engineer, Business Analyst), and adds a release readiness checklist and a role-responsibility template in docs/. These changes address gaps called out in issue #4 and make role ownership and release readiness explicit.
Linked issue: #4